### PR TITLE
Handle custom domain without base path

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-example.com
+alexdclark.dev

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you deploy to `https://<user>.github.io/<repo>`, set a base path so assets re
   ```
 - GitHub Actions already supports `NEXT_PUBLIC_BASE_PATH` via repository variables; set `NEXT_PUBLIC_BASE_PATH` to `/your-repo-name` in **Settings → Variables → Actions** when using a project site.
 
+For **custom domains** (when a `CNAME` file is present), do **not** set `NEXT_PUBLIC_BASE_PATH`. The site builds at the domain root without a repo subpath.
+
 ## GitHub Pages deployment
 Deployment is handled by `.github/workflows/deploy.yml` and uses the official Pages actions:
 1. Install dependencies and lint

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,22 @@
+import fs from "fs";
+
 const normalizeBasePath = (value = "") => {
   if (!value) return "";
   return value.startsWith("/") ? value : `/${value}`;
 };
 
-const basePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+const hasCustomDomain = (() => {
+  try {
+    const cname = fs.readFileSync(new URL("./CNAME", import.meta.url), "utf8").trim();
+    return Boolean(cname);
+  } catch {
+    return false;
+  }
+})();
+
+const basePath = hasCustomDomain
+  ? ""
+  : normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## Summary
- detect a custom domain via the CNAME file to avoid adding a repo base path when exporting
- update the CNAME to the alexdclark.dev domain
- clarify that NEXT_PUBLIC_BASE_PATH should stay unset when using a custom domain

## Testing
- npm run lint *(fails: next not found/registry restrictions in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b68d261c8320a83d95e15ce22d0e)